### PR TITLE
Fixed connect parsing the "`" character

### DIFF
--- a/src/preload/auto/steam-connect-fromlink.ts
+++ b/src/preload/auto/steam-connect-fromlink.ts
@@ -11,14 +11,14 @@ export default class SteamConnectLink extends AutoResponse {
         super(
             "steam connect link",
             "Automatically sends steam connect links when a detected clickable link is posted.",
-            /steam:\/\/connect\/(\w+\.)+\w+(:\d+)?\/.+/,
+            /steam:\/\/connect\/(\w+\.)+\w+(:\d+)?\/.+([^\n`$])([\"\s$])/,
             ["SEND_MESSAGES", "EMBED_LINKS"]
         )
     }
 
     async run(client: Client, msg: Message): Promise<void> {
         let connectLink = msg.content.match(this.pattern) as RegExpExecArray;
-        let parts = connectLink[0].replace("steam://connect/", "").split("/");
+        let parts = connectLink[0].trim().replace("steam://connect/", "").split("/");
         const lang: Language = await this.getLanguage(msg)
 
         let ip = parts[0];

--- a/src/preload/auto/steam-connect.ts
+++ b/src/preload/auto/steam-connect.ts
@@ -11,14 +11,14 @@ export default class SteamConnectLink extends AutoResponse {
         super(
             "steam connect info",
             "Automatically sends steam connect links when raw connect info is posted.",
-            /connect (https?:\/\/)?(.+\.)+\w+(:\d+)?; ?password .+/,
+            /connect (https?:\/\/)?(.+\.)+\w+(:\d+)?; ?password .+([^\n`$])([\"\s$])/,
             ["SEND_MESSAGES", "EMBED_LINKS"]
         )
     }
 
     async run(client: Client, msg: Message): Promise<void> {
         let connectInfo = msg.content.match(this.pattern) as RegExpExecArray;
-        let parts = connectInfo[0].split(";");
+        let parts = connectInfo[0].trim().split(";");
         const lang: Language = await this.getLanguage(msg)
 
         let ip = parts[0].replace(/^connect (https?:\/\/)?/, "");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55610086/91759950-1f3eff00-eb98-11ea-951b-48e18ff62625.png)
Works well enough to omit any characters after the last quote, and doesn't ever include a backtick. Works "good enough" for spaces in password, if that ever was a thing. Will never include stuff after quotes or last letter before whitespace in between backticks.